### PR TITLE
Fix README.md container startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ NVIDIA has worked with our camera partners to provide the modules listed below w
 3. Launch the Docker container using the `run_dev.sh` script:
 
     ```bash
-    cd ~/workspaces/isaac_ros-dev/src/isaac_ros_common && \
-      ./scripts/run_dev.sh
+    cd ~/workspaces/isaac_ros-dev && \
+      ./src/isaac_ros_common/scripts/run_dev.sh
     ```
 
 4. Inside the container, build and source the workspace:


### PR DESCRIPTION
Problem: when the container starts up, we are only inside the "common" package, the rest of the workspace does not get mounted to the container.

This fixes it.