### PR TITLE
Added framerate parameter to ArgusCameraNode

### DIFF
--- a/isaac_ros_argus_camera/include/isaac_ros_argus_camera/argus_camera_node.hpp
+++ b/isaac_ros_argus_camera/include/isaac_ros_argus_camera/argus_camera_node.hpp
@@ -90,6 +90,7 @@ protected:
   int camera_id_;
   int module_id_;
   int mode_;
+  int framerate_;
   int fsync_type_;
   bool use_hw_timestamp_;
   std::string camera_link_frame_name_;

--- a/isaac_ros_argus_camera/src/argus_camera_mono_node.cpp
+++ b/isaac_ros_argus_camera/src/argus_camera_mono_node.cpp
@@ -96,6 +96,7 @@ ArgusMonoNode::ArgusMonoNode(const rclcpp::NodeOptions & options)
   camera_id_ = declare_parameter<int>("camera_id", 0);
   module_id_ = declare_parameter<int>("module_id", 0);
   mode_ = declare_parameter<int>("mode", 0);
+  framerate_ = declare_parameter<int>("framerate", 30);
   fsync_type_ = declare_parameter<int>("fsync_type", 1);
   use_hw_timestamp_ = declare_parameter<bool>("use_hw_timestamp", false);
   camera_link_frame_name_ = declare_parameter<std::string>("camera_link_frame_name", "camera");

--- a/isaac_ros_argus_camera/src/argus_camera_node.cpp
+++ b/isaac_ros_argus_camera/src/argus_camera_node.cpp
@@ -378,6 +378,8 @@ void ArgusCameraNode::postLoadGraphCallback()
     "argus_camera", "nvidia::isaac::ArgusCamera", "fsync_type", fsync_type_);
   getNitrosContext().setParameterBool(
     "argus_camera", "nvidia::isaac::ArgusCamera", "use_hw_timestamp", use_hw_timestamp_);
+  getNitrosContext().setParameterInt32(
+    "argus_camera", "nvidia::isaac::ArgusCamera", "framerate", framerate_);
 }
 
 sensor_msgs::msg::CameraInfo::SharedPtr ArgusCameraNode::loadCameraInfoFromFile(

--- a/isaac_ros_argus_camera/src/argus_camera_stereo_node.cpp
+++ b/isaac_ros_argus_camera/src/argus_camera_stereo_node.cpp
@@ -119,6 +119,7 @@ ArgusStereoNode::ArgusStereoNode(const rclcpp::NodeOptions & options)
   camera_id_ = declare_parameter<int>("camera_id", 0);
   module_id_ = declare_parameter<int>("module_id", -1);
   mode_ = declare_parameter<int>("mode", 0);
+  framerate_ = declare_parameter<int>("framerate", 30);
   fsync_type_ = declare_parameter<int>("fsync_type", 1);
   use_hw_timestamp_ = declare_parameter<bool>("use_hw_timestamp", false);
   camera_link_frame_name_ =


### PR DESCRIPTION
The framerate of ArgusMonoNode was hardcoded to 30 fps in [argus_camera_mono_node.yaml](https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_argus_camera/blob/ec75c57ab5b7c3d7ee38aa773c08afd3e4ff43d0/isaac_ros_argus_camera/config/argus_camera_mono_node.yaml#L42) and likewise with argus_camera_stereo_node.yaml. If I need to change into a sensor mode with 60 FPS, instead of modifying those files in the repo's config folder, it is convenient to expose that as a ROS parameter as done with mode_ and others.

I have tested this with dual IMX676s, putting them into mode 2 (1776x1778 @ 60 FPS). With this parameter unlocked and set to 60 FPS in my launch file, I can now subscribe to downstream NitrosImages at full 60 FPS, and if I reduce the parameter setting it also reduces the framerate accordingly.

Would love to see this added in the next isaac_ros release!

Example usage in launch file:
```bash
left_argus_mono_node = ComposableNode(
    name='argus_mono_left',
    package='isaac_ros_argus_camera',
    plugin='nvidia::isaac_ros::argus::ArgusMonoNode',
    parameters=[{
        'camera_id':0,
        'mode':2,
        'framerate':60,
        'use_hw_timestamp':True,
        'camera_info_url':'file:///workspaces/isaac_ros-dev/calib.yaml'
    }],
)
```